### PR TITLE
Adding lxml and aacgmv2 as requirements for aurora_informer.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ Werkzeug==0.10.4
 argparse==1.2.1
 itsdangerous==0.24
 wsgiref==0.1.2
+lxml==3.4.4
+aacgmv2==1.0.10


### PR DESCRIPTION
There were 2 requirements missing when i tried to checkout and run tonite.  i added them to requirements.txt, with versions.  